### PR TITLE
120MHzで完動

### DIFF
--- a/core/boards/cpu.vhd
+++ b/core/boards/cpu.vhd
@@ -46,9 +46,9 @@ entity cpu is
 end entity cpu;
 
 architecture rtl of cpu is
-
   -- constant wtime : unsigned(15 downto 0) := x"035B";
-  constant wtime : unsigned(15 downto 0) := x"03ba";
+  -- constant wtime : unsigned(15 downto 0) := x"03ba"; -- 110MHz
+  constant wtime : unsigned(15 downto 0) := x"0203";  -- 120MHz, x24
 
   signal clk, iclk, dcm_clk1, dcm_clkfd, dcm_clkfx: std_logic;
 
@@ -84,8 +84,8 @@ begin
 
   dcm : dcm_base
     generic map (
-      clkfx_divide   => 3,
-      clkfx_multiply => 5)
+      clkfx_divide   => 5,
+      clkfx_multiply => 9)
     port map (
       rst      => not xrst,
       clkin    => iclk,

--- a/core/components/core.vhd
+++ b/core/components/core.vhd
@@ -364,8 +364,8 @@ architecture behavior of core is
           dst := r.w.alu_out;
           hz  := hz;
         when IWB_SRC_MEM =>
-          dst := mmuo.data;
-          hz  := hz;
+          dst := (others => '-');
+          hz  := '1';
       end case;
     else
       dst := v;
@@ -397,8 +397,8 @@ architecture behavior of core is
           dst := r.w.alu_out;
           hz  := hz;
         when IWB_SRC_MEM =>
-          dst := mmuo.data;
-          hz  := hz;
+          dst := (others => '-');
+          hz  := '1';
       end case;
     else
       dst := v;


### PR DESCRIPTION
メモリ命令のハザードが1clk分増える代わりに10MHzだけ周波数を向上できます。
